### PR TITLE
Update `CMD` on docker commit to override `ETH_RPC_URL` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ To authenticate, run `docker login ghcr.io` using your GitHub username and paste
 
 To push the package to the GitHub Container Repository:
 ```
-docker commit ajna-testnet ghcr.io/ajna-finance/ajna-testnet:<tag>
+docker commit --change='CMD ["--db", "/app/data", "--accounts", "16", "--wallet.seed", "20070213", "--port", "8555", "--fork", "${ETH_RPC_URL}@16295000", "-v"]' ajna-testnet ghcr.io/ajna-finance/ajna-testnet:<tag>
 docker push ghcr.io/ajna-finance/ajna-testnet:<tag>
 ```
 Visit [Ajna packages](https://github.com/orgs/ajna-finance/packages) and confirm the package has updated.

--- a/README.md
+++ b/README.md
@@ -174,13 +174,11 @@ You should receive a response like the following, which indicates a block height
 
 For first-time setup, visit [GitHub Developer Settings](https://github.com/settings/tokens) and create a new _personal access token (classic)_ with privileges to the _GitHub Package Repository_.  Set a reasonable expiration; the default is 7 days.  Record the token somewhere safe.
 
-To authenticate, run `docker login ghcr.io` using your GitHub username and paste your GitHub token as the password.
+To authenticate, run `docker login ghcr.io` using your GitHub username and paste your GitHub token as the password.  To publish, run the publishing script passing the release label as an argument:
+```
+./publish.sh rc6
+```
 
-To push the package to the GitHub Container Repository:
-```
-docker commit --change='CMD ["--db", "/app/data", "--accounts", "16", "--wallet.seed", "20070213", "--port", "8555", "--fork", "${ETH_RPC_URL}@16295000", "-v"]' ajna-testnet ghcr.io/ajna-finance/ajna-testnet:<tag>
-docker push ghcr.io/ajna-finance/ajna-testnet:<tag>
-```
 Visit [Ajna packages](https://github.com/orgs/ajna-finance/packages) and confirm the package has updated.
 
 ## Maintenance ##
@@ -189,3 +187,4 @@ Attach a shell to the bootnode:
 ```
 docker exec -it <image_name> /bin/sh
 ```
+

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+tag=${$1:?}
+
+echo "Use your GitHub username and paste your GitHub token as the password."
+docker login ghcr.io || exit 1
+
+# push the package to the GitHub Container Repository
+echo docker commit --change='CMD ["--db", "/app/data", "--accounts", "16", "--wallet.seed", "20070213", "--port", "8555", "--fork", "${ETH_RPC_URL}", "-v"]' ajna-testnet ghcr.io/ajna-finance/ajna-testnet:${tag} || exit 2
+echo docker push ghcr.io/ajna-finance/ajna-testnet:${tag}


### PR DESCRIPTION
- make use of `--change` switch in `docker commit` to update `CMD` within testchain image: https://docs.docker.com/engine/reference/commandline/commit/#change
- containers can be started from new image by passing `ETH_RPC_URL` env var (e.g. in `docker-compose` the `image: trufflesuite/ganache:latest` can be replaced with `image: ajna-finance/ajna-testnet:latest`)