### PR TITLE
feat: added optional env for a chain id

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: trufflesuite/ganache:latest
     ports:
       - 8555:8555
-    command: --db=/app/data --accounts 16 --chain.chainId 5124 --wallet.seed 20070213 --port 8555 -v
+    command: --db=/app/data --accounts 16 --chain.chainId ${CHAIN_ID:-5124} --wallet.seed 20070213 --port 8555 -v
     container_name: ajna-testnet
     networks:
       - ajna_test_network


### PR DESCRIPTION
Motivation:
If we have 2 or more chains with a same chain_id in Metamask, rpc url starts returning data randomly. So I added optional CHAIN_ID env variable for local env setup